### PR TITLE
cleaned up dependancy warnings

### DIFF
--- a/logstash-output-cloudwatchlogs.gemspec
+++ b/logstash-output-cloudwatchlogs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core', '>= 2.0.0', '< 6.0.0'
   s.add_runtime_dependency 'logstash-codec-plain', '>= 2.0.0', '< 6.0.0'
-  s.add_runtime_dependency 'logstash-mixin-aws', '>= 2.0.0'
+  s.add_runtime_dependency 'logstash-mixin-aws', '~> 2.0', '>= 2.0.0'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '~> 0'
 end


### PR DESCRIPTION
got rid of the warnings during build 

`WARNING:  open-ended dependency on logstash-mixin-aws (>= 2.0.0) is not recommended
  if logstash-mixin-aws is semantically versioned, use:
    add_runtime_dependency 'logstash-mixin-aws', '~> 2.0', '>= 2.0.0'
WARNING:  open-ended dependency on logstash-devutils (>= 0, development) is not recommended
  if logstash-devutils is semantically versioned, use:
    add_development_dependency 'logstash-devutils', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help`

